### PR TITLE
Upgrade version identified by pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import io
 from setuptools import setup, find_packages
 import sys
 
-VERSION = "0.0.3"
+VERSION = "0.0.4"
 PACKAGE_NAME = "riak_exporter"
 SOURCE_DIR_NAME = "src"
 


### PR DESCRIPTION
Temporary fix so that pip has the correct version elsewise it's `0.0.4` source code but with:

```
patsjo@~$ pip show riak_exporter
Name: riak-exporter
Version: 0.0.3
...
```

I'm also adding a thread to Riak in Twist to add this automatically in CI.