### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 ---
 name: ci
+permissions:
+  contents: read
 
 on:
   # for feature branches


### PR DESCRIPTION
Potential fix for [https://github.com/kivra/riak_exporter/security/code-scanning/2](https://github.com/kivra/riak_exporter/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow. Based on the provided workflow, it primarily interacts with the repository contents (e.g., checking out code) and does not appear to require write access. Therefore, we will set `contents: read` as the permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
