### PR TITLE
no-release(fix): `no-release` in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           fi
 
   release:
-    if: github.ref == 'refs/heads/master' && startsWith(github.event.head_commit.message, 'no-release:') == false
+    if: github.ref == 'refs/heads/master' && startsWith(github.event.head_commit.message, 'no-release') == false
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
> ⚠️ **Disclaimer** ⚠️ this is a Creative Friday initiative. A prior discussion around it might have not happened.

# Motivation

Have no releases for `no-release(fix): ...`, for example.

# Description

I recently merged with a message like `no-release(deps): ...` and this created an unwarranted release. This PR fixes that.